### PR TITLE
Add Redis caching to Django CRUD tasks

### DIFF
--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,0 +1,5 @@
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+class User(AbstractUser):
+    pass

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import User
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'username', 'email', 'first_name', 'last_name']

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from rest_framework.authtoken.views import obtain_auth_token
+from .views import UserViewSet
+
+router = DefaultRouter()
+router.register(r'users', UserViewSet, basename='user')
+
+urlpatterns = [
+    path('', include(router.urls)),
+    path('token/', obtain_auth_token, name='api_token_auth'),
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,0 +1,9 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
+from .models import User
+from .serializers import UserSerializer
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = [IsAuthenticated]

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -1,0 +1,138 @@
+"""
+Django settings for the project.
+"""
+
+import os
+from pathlib import Path
+
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = 'django-insecure-4#5$6%7&8*9(0)1@2!3^4&5*6(7)8_9+0-1=2#3$4%5^6&7*8(9)0'
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+# Application definition
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'task_manager',
+    'accounts',
+    'core',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'config.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'config.wsgi.application'
+
+# Database
+# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+# Password validation
+# https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+# Internationalization
+# https://docs.djangoproject.com/en/3.2/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/3.2/howto/static-files/
+
+STATIC_URL = '/static/'
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Django REST framework settings
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+}
+
+# Redis cache settings
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': 'redis://127.0.0.1:6379/1',
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+        }
+    }
+}

--- a/backend/config/settings/development.py
+++ b/backend/config/settings/development.py
@@ -1,0 +1,7 @@
+"""
+Development settings for the project.
+"""
+
+DEBUG = True
+
+ALLOWED_HOSTS = ['*']

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -1,0 +1,7 @@
+"""
+Production settings for the project.
+"""
+
+DEBUG = False
+
+ALLOWED_HOSTS = ['your-production-domain.com']

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('api/', include('task_manager.urls')),
+    path('api/auth/', include('accounts.urls')),
+]

--- a/backend/core/cache/decorators.py
+++ b/backend/core/cache/decorators.py
@@ -1,0 +1,8 @@
+from django.utils.decorators import decorator_from_middleware_with_args
+from django.views.decorators.cache import cache_page as django_cache_page
+
+def cache_page(timeout, cache=None, key_prefix=None):
+    """
+    Decorator to cache views for a specified timeout period.
+    """
+    return decorator_from_middleware_with_args(django_cache_page)(timeout, cache=cache, key_prefix=key_prefix)

--- a/backend/core/cache/patterns.py
+++ b/backend/core/cache/patterns.py
@@ -1,0 +1,8 @@
+def cache_key(prefix, *args):
+    """
+    Generate a cache key using the given prefix and arguments.
+    """
+    key = prefix
+    for arg in args:
+        key += f":{arg}"
+    return key

--- a/backend/core/cache/utils.py
+++ b/backend/core/cache/utils.py
@@ -1,0 +1,23 @@
+import redis
+from django.conf import settings
+
+redis_instance = redis.StrictRedis(
+    host=settings.REDIS_HOST,
+    port=settings.REDIS_PORT,
+    db=settings.REDIS_DB
+)
+
+def get_cache(key):
+    """
+    Retrieve a value from the Redis cache.
+    """
+    value = redis_instance.get(key)
+    if value:
+        return value.decode('utf-8')
+    return None
+
+def set_cache(key, value, timeout=None):
+    """
+    Set a value in the Redis cache with an optional timeout.
+    """
+    redis_instance.set(key, value, ex=timeout)

--- a/backend/task_manager/models.py
+++ b/backend/task_manager/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+
+class Task(models.Model):
+    title = models.CharField(max_length=255)
+    description = models.TextField()
+    completed = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.title

--- a/backend/task_manager/serializers.py
+++ b/backend/task_manager/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Task
+
+class TaskSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Task
+        fields = ['id', 'title', 'description', 'completed', 'created_at']

--- a/backend/task_manager/urls.py
+++ b/backend/task_manager/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import TaskViewSet
+
+router = DefaultRouter()
+router.register(r'tasks', TaskViewSet, basename='task')
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/backend/task_manager/views.py
+++ b/backend/task_manager/views.py
@@ -1,0 +1,48 @@
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from django.utils.decorators import method_decorator
+from .models import Task
+from .serializers import TaskSerializer
+from core.cache.decorators import cache_page
+
+class TaskViewSet(viewsets.ModelViewSet):
+    queryset = Task.objects.all()
+    serializer_class = TaskSerializer
+
+    @method_decorator(cache_page(60*15))
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    @method_decorator(cache_page(60*15))
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        return Response(serializer.data)
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_caching.py
+++ b/backend/tests/test_caching.py
@@ -1,0 +1,56 @@
+import pytest
+from rest_framework.test import APIClient
+from django.urls import reverse
+from task_manager.models import Task
+from core.cache.utils import get_cache, set_cache
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def create_task():
+    def _create_task(title, description, completed=False):
+        return Task.objects.create(title=title, description=description, completed=completed)
+    return _create_task
+
+@pytest.mark.django_db
+def test_task_list_caching(api_client, create_task):
+    url = reverse('task-list')
+    create_task('Task 1', 'Description 1')
+    create_task('Task 2', 'Description 2')
+
+    # First request to populate cache
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+    # Check if cache is set
+    cache_key = 'task_list'
+    cached_data = get_cache(cache_key)
+    assert cached_data is not None
+
+    # Second request to get data from cache
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+@pytest.mark.django_db
+def test_task_retrieve_caching(api_client, create_task):
+    task = create_task('Task 1', 'Description 1')
+    url = reverse('task-detail', args=[task.id])
+
+    # First request to populate cache
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['title'] == 'Task 1'
+
+    # Check if cache is set
+    cache_key = f'task_detail:{task.id}'
+    cached_data = get_cache(cache_key)
+    assert cached_data is not None
+
+    # Second request to get data from cache
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['title'] == 'Task 1'

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,73 @@
+import pytest
+from rest_framework.test import APIClient
+from django.urls import reverse
+from task_manager.models import Task
+from accounts.models import User
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+@pytest.fixture
+def create_task():
+    def _create_task(title, description, completed=False):
+        return Task.objects.create(title=title, description=description, completed=completed)
+    return _create_task
+
+@pytest.fixture
+def create_user():
+    def _create_user(username, password, email):
+        return User.objects.create_user(username=username, password=password, email=email)
+    return _create_user
+
+@pytest.mark.django_db
+def test_task_crud_operations(api_client, create_task):
+    # Create task
+    url = reverse('task-list')
+    data = {'title': 'Task 1', 'description': 'Description 1'}
+    response = api_client.post(url, data)
+    assert response.status_code == 201
+    assert response.data['title'] == 'Task 1'
+
+    # Retrieve task
+    task_id = response.data['id']
+    url = reverse('task-detail', args=[task_id])
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['title'] == 'Task 1'
+
+    # Update task
+    data = {'title': 'Updated Task 1'}
+    response = api_client.put(url, data)
+    assert response.status_code == 200
+    assert response.data['title'] == 'Updated Task 1'
+
+    # Delete task
+    response = api_client.delete(url)
+    assert response.status_code == 204
+
+@pytest.mark.django_db
+def test_user_crud_operations(api_client, create_user):
+    # Create user
+    url = reverse('user-list')
+    data = {'username': 'user1', 'password': 'password123', 'email': 'user1@example.com'}
+    response = api_client.post(url, data)
+    assert response.status_code == 201
+    assert response.data['username'] == 'user1'
+
+    # Retrieve user
+    user_id = response.data['id']
+    url = reverse('user-detail', args=[user_id])
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.data['username'] == 'user1'
+
+    # Update user
+    data = {'username': 'updated_user1'}
+    response = api_client.put(url, data)
+    assert response.status_code == 200
+    assert response.data['username'] == 'updated_user1'
+
+    # Delete user
+    response = api_client.delete(url)
+    assert response.status_code == 204

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,3 @@
+djangorestframework
+djangorestframework-simplejwt
+redis

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-django
+pytest-cov

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,2 @@
+gunicorn
+whitenoise


### PR DESCRIPTION
Add initial implementation of Redis Caching CRUD Tasks application with Django backend.

* **Settings and Configuration**
  - Add `base.py`, `development.py`, and `production.py` settings files with configurations for Django, REST framework, and Redis caching.
  - Add `urls.py` for root URL routing.

* **Task Manager App**
  - Add `Task` model with fields `title`, `description`, `completed`, and `created_at`.
  - Add `TaskSerializer` class for serializing `Task` model.
  - Add `TaskViewSet` class with CRUD operations and caching decorators for `list` and `retrieve` methods.
  - Add URL patterns for `TaskViewSet`.

* **User Authentication App**
  - Add `User` model extending `AbstractUser`.
  - Add `UserSerializer` class for serializing `User` model.
  - Add `UserViewSet` class with CRUD operations.
  - Add URL patterns for `UserViewSet` and `obtain_auth_token`.

* **Core Caching Functionality**
  - Add `cache_page` decorator for caching views.
  - Add `cache_key` function for generating cache keys.
  - Add `get_cache` and `set_cache` functions for interacting with Redis.

* **Testing**
  - Add tests for caching functionality in `TaskViewSet`.
  - Add integration tests for `TaskViewSet` and `UserViewSet`.

* **Requirements**
  - Add `djangorestframework`, `djangorestframework-simplejwt`, and `redis` packages to `base.txt`.
  - Add `pytest`, `pytest-django`, and `pytest-cov` packages to `dev.txt`.
  - Add `gunicorn` and `whitenoise` packages to `prod.txt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/redis-caching-crud-tasks/pull/1?shareId=34aaff4f-a57f-4dfb-9b66-3bca89478253).